### PR TITLE
Catch 0 length sarc buffer

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,6 +113,9 @@ impl SarcFile {
     /// **Note:** Compression requires the `yaz0_sarc` and/or the `zstd_sarc` features.
     pub fn read(data: &[u8]) -> Result<Self, Error> {
         let mut decompressed: Vec<u8>;
+        if data.len() < 4 {
+            return Err(Error::ParseError("Input buffer must be at least 4 bytes".into()));
+        }
         let data = {
             if b"Yaz0" == &data[..4] {
                 #[cfg(feature = "yaz0_sarc")] {


### PR DESCRIPTION
As it is, passing a buffer with a length of 0 to `SarcFile::read()` will panic, but naturally it would be nicer to return an error result instead.