### PR TITLE
Update 'nom' dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ zstd_sarc = ["zstd"]
 #required-features = ["sarctool"]
 
 [dependencies]
-nom = "5"
+nom = "7.1.1"
 binwrite = { version = "0.2.1" }
 yaz0 = { version = "0.1.2" , optional = true }
 zstd = { version = "0.5.1", optional = true }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ fn parse_sfat<E: TakeEndian>(data: &[u8]) -> IResult<&[u8], (u32, Vec<SfatNode>)
             take_u32::<E>,
             take_u32::<E>,
             take_u32::<E>,
-        ))(data)?;
+        ))(data).unwrap();
 
         const HAS_NAME: u32 = 0x01000000;
 
@@ -69,7 +69,7 @@ fn parse_sfat<E: TakeEndian>(data: &[u8]) -> IResult<&[u8], (u32, Vec<SfatNode>)
             name_offset,
             file_range: (file_start as usize..file_end as usize)
         }))
-    }, node_count as _)(data)?;
+    }, node_count as _)(data).unwrap();
     
     Ok((data, (hash_key, files)))
 }
@@ -197,7 +197,7 @@ impl SarcHeader {
             tag(b"SARC"),
             le_u16,
             be_u16,
-        ))(data)?;
+        ))(data).unwrap();
 
         match endian.into() {
             Endian::Big => Self::parse_endian::<BigEndian>(data, Endian::Big),


### PR DESCRIPTION
Updated the 'nom' dependency since compiling this package gave me `lexical-core` errors. Also replaced the `?` that the compiler complained about with unwraps.